### PR TITLE
feat: show default results and add logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,11 @@ from database import init_db, get_conn
 from file_indexer import index_files
 import threading
 import time
+import logging
 from config import XLSX_DIR
 
 app = Flask(__name__)
+logging.basicConfig(level=logging.INFO)
 
 # 后台索引线程
 def background_indexer():
@@ -28,43 +30,72 @@ def search():
     query = request.args.get('q', '')
     limit = int(request.args.get('limit', 50))
     offset = int(request.args.get('offset', 0))
-    
-    if not query:
-        return jsonify(results=[], count=0)
-    
+
     conn = get_conn()
     c = conn.cursor()
-    
-    # 使用FTS5进行高效搜索
-    c.execute("""
-        SELECT 
-            f.path, 
-            fts.sheet_name, 
-            fts.row_index, 
-            snippet(fts_index, 3, '<b>', '</b>', '...', 64) as snippet,
-            COUNT(*) OVER() AS full_count
-        FROM fts_index fts
-        JOIN files f ON f.id = fts.file_id
-        WHERE fts_index MATCH ?
-        ORDER BY rank
-        LIMIT ? OFFSET ?
-    """, (query, limit, offset))
-    
-    results = []
-    full_count = 0
-    
-    for row in c.fetchall():
-        if full_count == 0:
-            full_count = row[4]
-        results.append({
-            "file": row[0],
-            "sheet": row[1],
-            "row": row[2] + 1,  # 显示为1-based行号
-            "snippet": row[3]
-        })
-    
-    conn.close()
-    return jsonify(results=results, count=full_count)
+
+    try:
+        if not query:
+            c.execute(
+                """
+                SELECT f.path, fts.sheet_name, fts.row_index,
+                       substr(fts.content, 1, 100) AS snippet
+                FROM fts_index fts
+                JOIN files f ON f.id = fts.file_id
+                LIMIT ? OFFSET ?
+                """,
+                (limit, offset),
+            )
+            results = [
+                {
+                    "file": row[0],
+                    "sheet": row[1],
+                    "row": row[2] + 1,
+                    "snippet": row[3],
+                }
+                for row in c.fetchall()
+            ]
+            c.execute("SELECT COUNT(*) FROM fts_index")
+            full_count = c.fetchone()[0]
+        else:
+            # 使用FTS5进行高效搜索
+            c.execute(
+                """
+                SELECT
+                    f.path,
+                    fts.sheet_name,
+                    fts.row_index,
+                    snippet(fts_index, 3, '<b>', '</b>', '...', 64) as snippet,
+                    COUNT(*) OVER() AS full_count
+                FROM fts_index fts
+                JOIN files f ON f.id = fts.file_id
+                WHERE fts_index MATCH ?
+                ORDER BY rank
+                LIMIT ? OFFSET ?
+                """,
+                (query, limit, offset),
+            )
+
+            results = []
+            full_count = 0
+            for row in c.fetchall():
+                if full_count == 0:
+                    full_count = row[4]
+                results.append(
+                    {
+                        "file": row[0],
+                        "sheet": row[1],
+                        "row": row[2] + 1,
+                        "snippet": row[3],
+                    }
+                )
+
+        return jsonify(results=results, count=full_count)
+    except Exception:
+        app.logger.exception("搜索失败")
+        return jsonify(results=[], count=0, error="internal error"), 500
+    finally:
+        conn.close()
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, threaded=True)

--- a/app.py
+++ b/app.py
@@ -9,17 +9,22 @@ from config import XLSX_DIR
 app = Flask(__name__)
 logging.basicConfig(level=logging.INFO)
 
+
 # 后台索引线程
 def background_indexer():
     while True:
         index_files()
         time.sleep(300)  # 每5分钟检查一次
 
-@app.before_first_request
+
 def initialize():
+    """Initialize database and start background indexer."""
     init_db()
-    # 启动后台索引线程
     threading.Thread(target=background_indexer, daemon=True).start()
+
+
+# 初始化应用程序
+initialize()
 
 @app.route('/')
 def home():

--- a/file_indexer.py
+++ b/file_indexer.py
@@ -2,6 +2,7 @@ import os
 import pandas as pd
 import sqlite3
 import time
+import logging
 from config import XLSX_DIR, BATCH_SIZE
 from database import get_conn
 
@@ -23,7 +24,7 @@ def index_files():
                 if path in indexed_files and indexed_files[path] >= mod_time:
                     continue
                 
-                print(f"索引文件: {file}")
+                logging.info(f"索引文件: {file}")
                 try:
                     # 处理Excel文件
                     xl = pd.ExcelFile(path)
@@ -55,9 +56,9 @@ def index_files():
                             c.executemany("INSERT INTO fts_index VALUES (?, ?, ?, ?)", batch)
                     
                     conn.commit()
-                    print(f"完成索引: {file}, 工作表: {len(xl.sheet_names)}")
+                    logging.info(f"完成索引: {file}, 工作表: {len(xl.sheet_names)}")
                 
                 except Exception as e:
-                    print(f"索引失败 {file}: {str(e)}")
+                    logging.error(f"索引失败 {file}: {str(e)}")
     
     conn.close()

--- a/templates/index.html
+++ b/templates/index.html
@@ -132,12 +132,12 @@
         function performSearch() {
             const query = document.getElementById('search-input').value.trim();
             if (!query) return;
-            
+
             currentQuery = query;
             currentPage = 1;
             search(query, 1);
         }
-        
+
         function search(query, page) {
             const startTime = performance.now();
             const offset = (page - 1) * LIMIT;
@@ -219,10 +219,15 @@
             search(currentQuery, page);
             window.scrollTo({ top: 0, behavior: 'smooth' });
         }
-        
-        // 初始加载时自动索引文件
+
+        function loadDefaultResults() {
+            currentQuery = '';
+            currentPage = 1;
+            search('', 1);
+        }
+
         window.onload = function() {
-            fetch('/').then(() => console.log('后台索引已启动'));
+            loadDefaultResults();
         };
     </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,8 +131,6 @@
         
         function performSearch() {
             const query = document.getElementById('search-input').value.trim();
-            if (!query) return;
-
             currentQuery = query;
             currentPage = 1;
             search(query, 1);


### PR DESCRIPTION
## Summary
- display sample search results on the homepage by default
- add basic logging for indexing and search errors

## Testing
- `python -m py_compile app.py file_indexer.py database.py config.py`


------
https://chatgpt.com/codex/tasks/task_b_689d440c4528832bbf4216da14d9eb53