### PR TITLE
feat: add detail modal for search results

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,7 @@ def search():
         if not terms:
             base_query = (
                 "SELECT f.path, fts.sheet_name, fts.row_index, "
-                "substr(fts.content, 1, 100) AS snippet "
+                "substr(fts.content, 1, 100) AS snippet, fts.content "
                 "FROM fts_index fts "
                 "JOIN files f ON f.id = fts.file_id"
             )
@@ -72,6 +72,7 @@ def search():
                     "sheet": row[1],
                     "row": row[2] + 1,
                     "snippet": row[3],
+                    "content": row[4],
                 }
                 for row in c.fetchall()
             ]
@@ -91,7 +92,7 @@ def search():
             base_query = (
                 "SELECT f.path, fts.sheet_name, fts.row_index, "
                 "substr(fts.content, CASE WHEN instr(fts.content, ?) > 25 "
-                "THEN instr(fts.content, ?) - 25 ELSE 1 END, 100) AS snippet "
+                "THEN instr(fts.content, ?) - 25 ELSE 1 END, 100) AS snippet, fts.content "
                 "FROM fts_index fts JOIN files f ON f.id = fts.file_id "
                 "WHERE " + like_conditions
             )
@@ -115,6 +116,7 @@ def search():
                         "sheet": row[1],
                         "row": row[2] + 1,
                         "snippet": snippet,
+                        "content": row[4],
                     }
                 )
             count_query = (

--- a/templates/index.html
+++ b/templates/index.html
@@ -91,14 +91,55 @@
             margin-bottom: 10px;
             font-size: 14px;
         }
-        .snippet { 
-            color: #34495e; 
+        .snippet {
+            color: #34495e;
             line-height: 1.6;
             font-size: 16px;
         }
-        .pagination { 
-            display: flex; 
-            justify-content: center; 
+        .detail-btn {
+            margin-top: 10px;
+            background: #2ecc71;
+            color: white;
+            border: none;
+            padding: 6px 12px;
+            cursor: pointer;
+            border-radius: 4px;
+        }
+        .detail-btn:hover { background: #27ae60; }
+        .modal {
+            display: none;
+            position: fixed;
+            z-index: 1000;
+            left: 0;
+            top: 0;
+            width: 100%;
+            height: 100%;
+            overflow: auto;
+            background-color: rgba(0,0,0,0.4);
+        }
+        .modal-content {
+            background: white;
+            margin: 10% auto;
+            padding: 20px;
+            border-radius: 8px;
+            width: 80%;
+            max-height: 80%;
+            overflow-y: auto;
+            line-height: 1.6;
+        }
+        .modal-content pre {
+            white-space: pre-wrap;
+            word-break: break-all;
+        }
+        .close {
+            float: right;
+            font-size: 28px;
+            font-weight: bold;
+            cursor: pointer;
+        }
+        .pagination {
+            display: flex;
+            justify-content: center;
             margin: 30px 0;
         }
         .page-btn {
@@ -151,8 +192,15 @@
         </div>
         
         <div id="results-container"></div>
-        
+
         <div class="pagination" id="pagination"></div>
+    </div>
+
+    <div id="detail-modal" class="modal">
+        <div class="modal-content">
+            <span id="modal-close" class="close">&times;</span>
+            <pre id="modal-text"></pre>
+        </div>
     </div>
 
     <script>
@@ -162,6 +210,7 @@
         let currentQuery = '';
         let currentExtra = '';
         let currentExclude = '';
+        let currentResults = [];
 
         document.getElementById('search-button').addEventListener('click', performSearch);
         document.getElementById('search-input').addEventListener('keyup', function(e) {
@@ -171,6 +220,21 @@
             if (e.key === 'Enter') performSearch();
         });
         document.getElementById('reset-db-button').addEventListener('click', resetDatabase);
+        document.getElementById('results-container').addEventListener('click', function(e) {
+            if (e.target.classList.contains('detail-btn')) {
+                const idx = e.target.getAttribute('data-index');
+                showDetail(currentResults[idx].content);
+            }
+        });
+        document.getElementById('modal-close').onclick = function() {
+            document.getElementById('detail-modal').style.display = 'none';
+        };
+        window.onclick = function(event) {
+            const modal = document.getElementById('detail-modal');
+            if (event.target === modal) {
+                modal.style.display = 'none';
+            }
+        };
 
         function performSearch() {
             const query = document.getElementById('search-input').value.trim();
@@ -237,6 +301,7 @@
             const container = document.getElementById('results-container');
             document.getElementById('result-count').textContent = `${count} 个结果`;
             document.getElementById('search-time').textContent = `响应时间: ${duration}ms`;
+            currentResults = results;
             
             if (results.length === 0) {
                 container.innerHTML = '<div class="empty-state">未找到匹配结果</div>';
@@ -244,12 +309,13 @@
             }
             
             let html = '';
-            results.forEach(result => {
+            results.forEach((result, idx) => {
                 html += `
                 <div class="result-item">
                     <div class="file-path">${result.file}</div>
                     <div class="sheet-info">工作表: ${result.sheet} | 行号: ${result.row}</div>
                     <div class="snippet">${result.snippet}</div>
+                    <button class="detail-btn" data-index="${idx}">查看详情</button>
                 </div>
                 `;
             });
@@ -291,6 +357,11 @@
             currentPage = page;
             search(currentQuery, currentExtra, page);
             window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+
+        function showDetail(text) {
+            document.getElementById('modal-text').textContent = text;
+            document.getElementById('detail-modal').style.display = 'block';
         }
 
         function loadDefaultResults() {


### PR DESCRIPTION
## Summary
- include full row content in search API results
- add detail modal and buttons in the UI to view entire cell content

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689da34c00a0832b9b9747790dfdc590