### PR TITLE
feat: show details on title click

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,14 +80,15 @@
             transition: transform 0.2s;
         }
         .result-item:hover { transform: translateY(-3px); }
-        .file-path { 
-            color: #2c3e50; 
+        .file-path {
+            color: #2c3e50;
             font-weight: bold;
             margin-bottom: 5px;
             font-size: 18px;
+            cursor: pointer;
         }
-        .sheet-info { 
-            color: #3498db; 
+        .sheet-info {
+            color: #3498db;
             margin-bottom: 10px;
             font-size: 14px;
         }
@@ -96,16 +97,6 @@
             line-height: 1.6;
             font-size: 16px;
         }
-        .detail-btn {
-            margin-top: 10px;
-            background: #2ecc71;
-            color: white;
-            border: none;
-            padding: 6px 12px;
-            cursor: pointer;
-            border-radius: 4px;
-        }
-        .detail-btn:hover { background: #27ae60; }
         .modal {
             display: none;
             position: fixed;
@@ -221,7 +212,7 @@
         });
         document.getElementById('reset-db-button').addEventListener('click', resetDatabase);
         document.getElementById('results-container').addEventListener('click', function(e) {
-            if (e.target.classList.contains('detail-btn')) {
+            if (e.target.classList.contains('file-path')) {
                 const idx = e.target.getAttribute('data-index');
                 showDetail(currentResults[idx].content);
             }
@@ -312,10 +303,9 @@
             results.forEach((result, idx) => {
                 html += `
                 <div class="result-item">
-                    <div class="file-path">${result.file}</div>
+                    <div class="file-path" data-index="${idx}">${result.file}</div>
                     <div class="sheet-info">工作表: ${result.sheet} | 行号: ${result.row}</div>
                     <div class="snippet">${result.snippet}</div>
-                    <button class="detail-btn" data-index="${idx}">查看详情</button>
                 </div>
                 `;
             });


### PR DESCRIPTION
## Summary
- hide detail button and trigger details by clicking result title

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_689dac44df64832b8fb9c6b580d23ecc